### PR TITLE
chore: fix check for the `--open` flag

### DIFF
--- a/crates/launcher/src/main.rs
+++ b/crates/launcher/src/main.rs
@@ -110,8 +110,8 @@ fn main() {
             println!("\n{}", repo_vscode_url);
 
             if matches
-                .get_one::<String>("port")
-                .expect("port has default value")
+                .get_one::<String>("open")
+                .expect("open has a default value")
                 == "true"
             {
                 let _ = std::process::Command::new("xdg-open")


### PR DESCRIPTION
I noticed an issue where the check for the port flag (`--port`) was incorrectly compared with the string `"true"`. This was causing unintended behavior, as the port is a numerical string (e.g., `"6699"`), not a boolean value.

The issue has been corrected by replacing the port check with the correct check for the `--open` flag. Now, the `--open` flag is properly checked, and if it’s set to `"true"`, the browser will be opened.

This fix ensures that the program behaves as expected, opening the browser when requested.