### PR TITLE
chore: update GitHub actions in CI workflows

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ['ubuntu-latest']
     steps:
       - name: 'Checkout Code'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: 'Install Nix'
         uses: cachix/install-nix-action@master


### PR DESCRIPTION
Updates actions/checkout@v4 to actions/checkout@v5 across CI workflows.

Upgrade to actions/checkout@v5 for improved performance and stability.

Reference:
Latest version: https://github.com/actions/checkout/releases/tag/v5.0.0